### PR TITLE
chore(esbuild-inject-plugin): update esbuild peer dep to work with pa…

### DIFF
--- a/packages/esbuild-inject-plugin/package.json
+++ b/packages/esbuild-inject-plugin/package.json
@@ -6,7 +6,7 @@
   "author": "Alexander Kuznetsov <alexkuz@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "esbuild": "0.14.22"
+    "esbuild": "~0.14.22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To avoid this error message:
```
Conflicting peer dependency: esbuild@0.14.22
```
and allow patches versions of `esbuild`(so 0.14.x).